### PR TITLE
use intent only when intent support is certain.

### DIFF
--- a/lib/web2app.js
+++ b/lib/web2app.js
@@ -28,12 +28,10 @@
             willInvokeApp();
 
             if (os.android) {
-                if (isIntentNotSupportedBrowser() || !!context.useUrlScheme) {
-                    if (context.storeURL) {
-                        web2appViaCustomUrlSchemeForAndroid(context.urlScheme, context.storeURL, onAppMissing);
-                    }
-                } else if (context.intentURI){
+                if (isIntentSupportedBrowser() && context.intentURI && !context.useUrlScheme) {
                     web2appViaIntentURI(context.intentURI);
+                } else if (context.storeURL) {
+                    web2appViaCustomUrlSchemeForAndroid(context.urlScheme, context.storeURL, onAppMissing);
                 }
             } else if (os.ios && context.storeURL) {
                 web2appViaCustomUrlSchemeForIOS(context.urlScheme, context.storeURL, onAppMissing);
@@ -44,9 +42,11 @@
             }
         }
         
-        function isIntentNotSupportedBrowser () {
+        // chrome 25 and later supports intent. https://developer.chrome.com/multidevice/android/intents
+        function isIntentSupportedBrowser () {
+            var supportsIntent = ua.browser.chrome && +(ua.browser.version.major) >= 25;
             var blackListRegexp = new RegExp(intentNotSupportedBrowserList.join('|'), "i");
-            return blackListRegexp.test(ua.ua);
+            return supportsIntent && !blackListRegexp.test(ua.ua);
         }
 
         function web2appViaCustomUrlSchemeForAndroid (urlScheme, storeURL, fallback) {


### PR DESCRIPTION
use intent only when intent support is certain. old logic fails for old android webviews.
